### PR TITLE
Do not always allocate a tty on `connect`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,11 @@ $ dokku postgres:unlink db9.4 my_app
 # And last, destroy the old container
 $ dokku postgres:destroy db9.4
 ```
+
+## importing data
+
+The `import` command should be used with any non-plain-text files exported by `pg_dump`. To import a SQL file, use `connect` like this:
+
+```shell
+$ dokku postgres:connect db < ./dump.sql
+```

--- a/commands
+++ b/commands
@@ -167,8 +167,9 @@ case "$1" in
     SERVICE="$2"; SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
     DATABASE_NAME="$(get_database_name $SERVICE)"
     SERVICE_NAME="$(get_service_name "$SERVICE")"
+    has_tty && SERVICE_TTY_OPTS="-t"
 
-    docker exec -it "$SERVICE_NAME" psql -h localhost -U postgres "$DATABASE_NAME"
+    docker exec -i $SERVICE_TTY_OPTS "$SERVICE_NAME" psql -h localhost -U postgres "$DATABASE_NAME"
     ;;
 
   $PLUGIN_COMMAND_PREFIX:info)

--- a/tests/service_connect.bats
+++ b/tests/service_connect.bats
@@ -24,6 +24,6 @@ teardown() {
 @test "($PLUGIN_COMMAND_PREFIX:connect) success" {
   export ECHO_DOCKER_COMMAND="true"
   run dokku "$PLUGIN_COMMAND_PREFIX:connect" l
-  assert_output 'docker exec -it dokku.postgres.l psql -h localhost -U postgres l'
+  assert_output 'docker exec -i -t dokku.postgres.l psql -h localhost -U postgres l'
 }
 


### PR DESCRIPTION
To import SQL files `connect` has to be used instead of `import`. Doing
so can’t work with the `-t` docker option, so now we check for a tty
before using this option.

Fixes #18