### PR TITLE
Fix /var/lib/postgresql/data volume mount point

### DIFF
--- a/commands
+++ b/commands
@@ -32,7 +32,7 @@ case "$1" in
 
     dokku_log_info1 "Starting container"
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT:/var/lib/postgresql" -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
Postgres images on dockerhub uses `/var/lib/postgresql/data` [volume](https://github.com/docker-library/postgres/blob/cd294bf8dfdf4a74b2077aa6413fa579f9bf07de/9.4/Dockerfile#L43) and not `/var/lib/postgresql`.

After upgrading, users will need to manually copy `/var/lib/docker/volumes/../_data` to `/var/lib/dokku/services/postgres/<app>/data`

You can get the current mount points using `docker inspect <container-id>`

```
"Mounts": [
    {
        "Name": "b1dd1a42222da699c82314a855b6ff3ac10bde3cd27bffbf7ef45ef43e6358de",
        "Source": "/var/lib/docker/volumes/b1dd1a42222da699c82314a855b6ff3ac10bde3cd27bffbf7ef45ef43e6358de/_data",
        "Destination": "/var/lib/postgresql/data",
        "Driver": "local",
        "Mode": "",
        "RW": true
    },
    {
        "Source": "/var/lib/dokku/services/postgres/<app>",
        "Destination": "/var/lib/postgresql",
        "Mode": "",
        "RW": true
    }
],
```