### PR TITLE
Allow use of postgres images with wal-e

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
 ```
 postgres:clone <name> <new-name>  Create container <new-name> then copy data from <name> into <new-name>
 postgres:connect <name>           Connect via psql to a postgres service
-postgres:create <name> <env=val>  Create a postgres service with environment variables
+postgres:create <name>            Create a postgres service with environment variables
 postgres:destroy <name>           Delete the service and stop its container if there are no links left
 postgres:export <name>            Export a dump of the postgres service database
 postgres:expose <name> [port]     Expose a postgres service on custom port if provided (random port otherwise)
@@ -52,6 +52,7 @@ dokku postgres:create lolipop
 # official postgres image
 export POSTGRES_IMAGE="postgres"
 export POSTGRES_IMAGE_VERSION="9.4.4"
+export POSTGRES_DOCKER_ARGS="USER=alpha;HOST=beta"
 dokku postgres:create lolipop
 
 # get connection information as follows

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dokku postgres:create lolipop
 # official postgres image
 export POSTGRES_IMAGE="postgres"
 export POSTGRES_IMAGE_VERSION="9.4.4"
-export POSTGRES_DOCKER_ARGS="USER=alpha;HOST=beta"
+export POSTGRES_CUSTOM_ENV="USER=alpha;HOST=beta"
 dokku postgres:create lolipop
 
 # get connection information as follows

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
 ```
 postgres:clone <name> <new-name>  Create container <new-name> then copy data from <name> into <new-name>
 postgres:connect <name>           Connect via psql to a postgres service
-postgres:create <name>            Create a postgres service
+postgres:create <name> <env=val>  Create a postgres service with environment variables
 postgres:destroy <name>           Delete the service and stop its container if there are no links left
 postgres:export <name>            Export a dump of the postgres service database
 postgres:expose <name> [port]     Expose a postgres service on custom port if provided (random port otherwise)

--- a/commands
+++ b/commands
@@ -44,7 +44,7 @@ case "$1" in
 
     dokku_log_verbose_quiet "Creating container database"
     DATABASE_NAME="$(get_database_name "$SERVICE")"
-    docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME"
+    docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME 2> /dev/null || echo 'Already exists'"
 
     dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
     dokku "$PLUGIN_COMMAND_PREFIX:info" "$SERVICE"

--- a/commands
+++ b/commands
@@ -44,7 +44,7 @@ case "$1" in
 
     dokku_log_verbose_quiet "Creating container database"
     DATABASE_NAME="$(get_database_name "$SERVICE")"
-    docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME 2> /dev/null || echo 'Already exists'"
+    docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME" 2> /dev/null || echo 'Already exists'
 
     dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
     dokku "$PLUGIN_COMMAND_PREFIX:info" "$SERVICE"

--- a/commands
+++ b/commands
@@ -31,8 +31,12 @@ case "$1" in
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"
+    ENVIRONMENT=""
+    for arg in "${@:2}"; do
+     ENVIRONMENT="$ENVIRONMENT -e $arg"
+    done
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" $ENVIRONMENT -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"

--- a/commands
+++ b/commands
@@ -31,8 +31,8 @@ case "$1" in
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"
-    if [[ -n $POSTGRES_DOCKER_ARGS ]]; then
-      echo "$POSTGRES_DOCKER_ARGS" | tr ';' "\n" > "$SERVICE_ROOT/ENVIRONMENT"
+    if [[ -n $POSTGRES_CUSTOM_ENV ]]; then
+      echo "$POSTGRES_CUSTOM_ENV" | tr ';' "\n" > "$SERVICE_ROOT/ENVIRONMENT"
     else
       echo "" > "$SERVICE_ROOT/ENVIRONMENT"
     fi

--- a/commands
+++ b/commands
@@ -31,8 +31,8 @@ case "$1" in
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"
-    if [ -n $POSTGRES_DOCKER_ARGS ]; then
-      echo "$(echo $POSTGRES_DOCKER_ARGS | tr ',' "\n")" > "$SERVICE_ROOT/ENVIRONMENT"
+    if [[ -n $POSTGRES_DOCKER_ARGS ]]; then
+      echo "$POSTGRES_DOCKER_ARGS" | tr ';' "\n" > "$SERVICE_ROOT/ENVIRONMENT"
     else
       echo "" > "$SERVICE_ROOT/ENVIRONMENT"
     fi

--- a/commands
+++ b/commands
@@ -31,12 +31,13 @@ case "$1" in
     touch "$LINKS_FILE"
 
     dokku_log_info1 "Starting container"
-    ENVIRONMENT=""
-    for arg in "${@:2}"; do
-     ENVIRONMENT="$ENVIRONMENT -e $arg"
-    done
+    if [ -n $POSTGRES_DOCKER_ARGS ]; then
+      echo "$(echo $POSTGRES_DOCKER_ARGS | tr ',' "\n")" > "$SERVICE_ROOT/ENVIRONMENT"
+    else
+      echo "" > "$SERVICE_ROOT/ENVIRONMENT"
+    fi
     SERVICE_NAME=$(get_service_name "$SERVICE")
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" $ENVIRONMENT -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" --env-file="$SERVICE_ROOT/ENVIRONMENT" -e "POSTGRES_PASSWORD=$password" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"


### PR DESCRIPTION
I'd like to be able to start postgres images which have wal-e installed to allow for continous backups as well as restores from backups (see https://github.com/mcolyer/docker-postgres-wale for details). In order to do that I needed to be able to:

* Pass arbitrary environment variables to the underlying docker container
* Permit `postgres:create` to proceed even if the database already exists.

In order to do that I changed the signature of `postgres:create` to permit environment variable pairs to be passed through. I'm open to other suggestions but this seemed the simplest way to achieve what I was looking for.