### PR TITLE
Enable SSL for connections to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,12 @@ The `import` command should be used with any non-plain-text files exported by `p
 ```shell
 $ dokku postgres:connect db < ./dump.sql
 ```
+
+## security
+
+The connection to the database is done over SSL. A self-signed certificate is
+automatically generated when creating the service.  It can be replaced by a
+custom certificate by overwriting the `server.crt` and `server.key` files in
+`/var/lib/dokku/services/postgres/<DB_NAME>/data`.
+The `server.key` must be chmoded to 600 and must be owned by the postgres user
+or root.

--- a/commands
+++ b/commands
@@ -48,6 +48,11 @@ case "$1" in
     DATABASE_NAME="$(get_database_name "$SERVICE")"
     docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME" 2> /dev/null || echo 'Already exists'
 
+    dokku_log_verbose_quiet "Securing connection to database"
+    service_stop "$SERVICE" > /dev/null
+    docker run --rm -i -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s < "$(dirname "$0")/scripts/enable_ssl.sh" &> /dev/null
+    service_start "$SERVICE" > /dev/null
+
     dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
     dokku "$PLUGIN_COMMAND_PREFIX:info" "$SERVICE"
     ;;

--- a/scripts/enable_ssl.sh
+++ b/scripts/enable_ssl.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /var/lib/postgresql/data
+openssl req -new -newkey rsa:4096 -x509 -nodes -out server.crt -keyout server.key -batch
+chmod 600 server.key
+sed -i "s/^#ssl = off/ssl = on/" postgresql.conf
+sed -i "s/^#ssl_ciphers =.*/ssl_ciphers = 'AES256+EECDH:AES256+EDH'/" postgresql.conf

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -15,6 +15,7 @@ cd -
 rm -rf $DOKKU_ROOT/plugins/service
 mkdir -p $DOKKU_ROOT/plugins/service
 find ./ -maxdepth 1 -type f -exec cp '{}' $DOKKU_ROOT/plugins/service \;
+cp -r ./scripts "$DOKKU_ROOT/plugins/service"
 
 if [[ ! -f $BIN_STUBS/plugn ]]; then
   wget -O- "$PLUGN_URL" | tar xzf - -C "$BIN_STUBS"


### PR DESCRIPTION
Since the database can be exposed to the outer world, it seems better to
have an encrypted connection to it.
We automatically generate a self-signed certificate since it's only used
to encrypt the connection but one can easily replace it by a custom one,
just overwrite `server.crt` and `server.key` in the
/var/lib/dokku/services/postgres/DB_NAME/data directory.