### PR TITLE
Fix exit code for postgres:export when SSH_TTY is not present

### DIFF
--- a/commands
+++ b/commands
@@ -128,7 +128,9 @@ case "$1" in
 
     [[ -n $SSH_TTY ]] && stty -opost
     docker exec "$SERVICE_NAME" env PGPASSWORD="$PASSWORD" pg_dump -Fc --no-acl --no-owner -h localhost -U postgres -w "$DATABASE_NAME"
+    status=$?
     [[ -n $SSH_TTY ]] && stty opost
+    exit $status
     ;;
 
   $PLUGIN_COMMAND_PREFIX:import)

--- a/tests/service_export.bats
+++ b/tests/service_export.bats
@@ -21,10 +21,20 @@ teardown() {
   assert_contains "${lines[*]}" "service not_existing_service does not exist"
 }
 
-@test "($PLUGIN_COMMAND_PREFIX:export) success" {
+@test "($PLUGIN_COMMAND_PREFIX:export) success with SSH_TTY" {
   export ECHO_DOCKER_COMMAND="true"
+  export SSH_TTY=`tty`
   run dokku "$PLUGIN_COMMAND_PREFIX:export" l
   password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  assert_exit_status 0
   assert_output "docker exec dokku.postgres.l env PGPASSWORD=$password pg_dump -Fc --no-acl --no-owner -h localhost -U postgres -w l"
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:export) success without SSH_TTY" {
+  export ECHO_DOCKER_COMMAND="true"
+  unset SSH_TTY
+  run dokku "$PLUGIN_COMMAND_PREFIX:export" l
+  password="$(cat "$PLUGIN_DATA_ROOT/l/PASSWORD")"
+  assert_exit_status 0
+  assert_output "docker exec dokku.postgres.l env PGPASSWORD=$password pg_dump -Fc --no-acl --no-owner -h localhost -U postgres -w l"
+}


### PR DESCRIPTION
The same issue is also with other dokku services.