### PR TITLE
Adds continuous archiving feature.

### DIFF
--- a/commands
+++ b/commands
@@ -99,6 +99,18 @@ case "$1" in
     "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/unlink" "$@"
     ;;
 
+  $PLUGIN_COMMAND_PREFIX:wal-enable)
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/wal-enable" "$@"
+    ;;
+
+  $PLUGIN_COMMAND_PREFIX:wal-disable)
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/wal-disable" "$@"
+    ;;
+
+  $PLUGIN_COMMAND_PREFIX:wal-recover)
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/subcommands/wal-recover" "$@"
+    ;;
+
   help | $PLUGIN_COMMAND_PREFIX:help)
     help_content_func() {
       # shellcheck disable=SC2034
@@ -126,6 +138,9 @@ case "$1" in
     $PLUGIN_COMMAND_PREFIX:stop <name>, Stop a running $PLUGIN_SERVICE service
     $PLUGIN_COMMAND_PREFIX:unexpose <name>, Unexpose a previously exposed $PLUGIN_SERVICE service
     $PLUGIN_COMMAND_PREFIX:unlink <name> <app>, Unlink the $PLUGIN_SERVICE service from the app
+    $PLUGIN_COMMAND_PREFIX:wal-enable <name>, Enable continuous WAL segment archiving for <name>
+    $PLUGIN_COMMAND_PREFIX:wal-disable <name>, Disable continuous WAL segment archiving for <name>. This command will keep previously archived WAL segment
+    $PLUGIN_COMMAND_PREFIX:wal-recover <name> [timestamp], Recover from backups generated with $PLUGIN_COMMAND_PREFIX:wal-enable. Example timestamp format: '2016-07-14 22:39:00 EST'
 help_content
     }
 

--- a/functions
+++ b/functions
@@ -42,7 +42,7 @@ service_create_container() {
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
   local PREVIOUS_ID
 
-  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$PASSWORD" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" -v "$SERVICE_ROOT/backups:/var/lib/postgresql/backups" -e "POSTGRES_PASSWORD=$PASSWORD" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
   echo "$ID" > "$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"
@@ -127,3 +127,4 @@ service_url() {
   local SERVICE_ALIAS="$(service_alias "$SERVICE")"
   echo "$PLUGIN_SCHEME://postgres:$PASSWORD@$SERVICE_ALIAS:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }
+

--- a/scripts/disable_wal.sh
+++ b/scripts/disable_wal.sh
@@ -1,0 +1,8 @@
+POSTGRES_CONF="/var/lib/postgresql/data/postgresql.conf"
+PG_HBA_CONF="/var/lib/postgresql/data/pg_hba.conf"
+
+sed -i 's/^.*wal_level.*/wal_level = minimal/' $POSTGRES_CONF
+sed -i 's/^.*archive_mode.*/archive_mode = off/' $POSTGRES_CONF
+sed -i 's/^.*max_wal_senders.*/max_wal_senders = 0/' $POSTGRES_CONF
+
+sed -i "/replication.*postgres/s/^/#/g" $PG_HBA_CONF

--- a/scripts/enable_wal.sh
+++ b/scripts/enable_wal.sh
@@ -1,0 +1,10 @@
+POSTGRES_CONF="/var/lib/postgresql/data/postgresql.conf"
+PG_HBA_CONF="/var/lib/postgresql/data/pg_hba.conf"
+
+sed -i 's/^.*wal_level.*/wal_level = archive/' $POSTGRES_CONF
+sed -i 's/^.*archive_mode.*/archive_mode = on/' $POSTGRES_CONF
+sed -i 's/^.*archive_timeout.*/archive_timeout = 60/' $POSTGRES_CONF
+sed -i "s/^.*archive_command.*/archive_command = 'cp %p \/var\/lib\/postgresql\/backups \&\& gzip \/var\/lib\/postgresql\/backups\/%f'/" $POSTGRES_CONF
+sed -i 's/^.*max_wal_senders.*/max_wal_senders = 2/' $POSTGRES_CONF
+
+sed -i "/replication.*postgres/s/^#//g" $PG_HBA_CONF

--- a/subcommands/destroy
+++ b/subcommands/destroy
@@ -45,6 +45,7 @@ postgres-destroy-cmd() {
 
   dokku_log_verbose_quiet "Removing data"
   docker run --rm -v "$SERVICE_ROOT/data:/data" -v "$SERVICE_ROOT/config:/config" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" chmod 777 -R /config /data
+  test -e $SERVICE_ROOT/backups && docker run --rm -v "$SERVICE_ROOT/backups:/backups" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" chmod 777 -R /backups
   rm -rf "$SERVICE_ROOT"
 
   dokku_log_info2 "$PLUGIN_SERVICE container deleted: $SERVICE"

--- a/subcommands/wal-disable
+++ b/subcommands/wal-disable
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+postgres-wal-disable-cmd() {
+  [[ -z $2 ]] && dokku_log_fail "Please specify a name for the service"
+  verify_service_name "$2"
+
+  local SERVICE="$2"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+  local SERVICE_NAME=$(get_service_name "$SERVICE")
+  local PASSWORD=$(cat "$SERVICE_ROOT/PASSWORD")
+  local DISABLE_SCRIPT_PATH="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/scripts/disable_wal.sh"
+  local DOCKER_RUN_ARGS=(run --rm -i -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+
+  if [[ ! -e "$SERVICE_ROOT/backups/base" ]]; then
+    dokku_log_fail "WAL seems to never have been enabled"
+  fi
+
+  if docker "${DOCKER_RUN_ARGS[@]}" cat /var/lib/postgresql/data/postgresql.conf | grep 'archive_mode.*off' > /dev/null; then
+    dokku_log_fail "WAL seems to have already been disabled"
+  fi
+
+  dokku_log_verbose_quiet "Writing postgresql.conf and pg_hba.conf"
+  docker "${DOCKER_RUN_ARGS[@]}" bash -s < $DISABLE_SCRIPT_PATH
+
+  service_stop "$SERVICE"
+  service_start "$SERVICE"
+
+  dokku_log_verbose_quiet "WAL incremental backup disabled"
+  dokku_log_verbose_quiet "The base backup and the WAL segments in $SERVICE_ROOT/backups are NOT removed"
+}
+
+postgres-wal-disable-cmd "$@"

--- a/subcommands/wal-enable
+++ b/subcommands/wal-enable
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+postgres-wal-enable-cmd() {
+  [[ -z $2 ]] && dokku_log_fail "Please specify a name for the service"
+  verify_service_name "$2"
+
+  local SERVICE="$2"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+  local SERVICE_NAME=$(get_service_name "$SERVICE")
+  local PASSWORD=$(cat "$SERVICE_ROOT/PASSWORD")
+  local ENABLE_SCRIPT_PATH="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/scripts/enable_wal.sh"
+  local DOCKER_RUN_ARGS=(run --rm -i -v "$SERVICE_ROOT/backups:/var/lib/postgresql/backups" -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+  local FORCE="$3"
+
+  if [[ -e "$SERVICE_ROOT/backups/base" ]]; then
+    # If backup directory already exists
+
+    # Check config file to see if WAL is already enabled
+    if docker "${DOCKER_RUN_ARGS[@]}" cat /var/lib/postgresql/data/postgresql.conf | grep 'archive_mode.*on' > /dev/null; then
+      dokku_log_fail "WAL seems to have already been enabled"
+    fi
+
+    # If WAL is current disabled, start over only if we're given -f
+    if [[ $FORCE == "-f" ]]; then
+      dokku_log_verbose_quiet "Removing previous backup files"
+      docker ${DOCKER_RUN_ARGS[@]} find /var/lib/postgresql/backups -mindepth 1 -delete
+    else
+      dokku_log_fail "$SERVICE_ROOT/backups/base already exists. Use -f to remove it and start over. "
+    fi
+  else
+    # Create the backup directory and attach it to the container
+    dokku_log_verbose_quiet "Recreating container to attach directory for backups"
+
+    service_stop "$SERVICE"
+    sleep 1
+
+    dokku_log_verbose_quiet "Removing container"
+    docker rm -v "$SERVICE_NAME" > /dev/null
+
+    service_create_container "$SERVICE"
+  fi
+
+  # Writing config files to enable WAL
+  dokku_log_verbose_quiet "Writing postgresql.conf and pg_hba.conf"
+  docker "${DOCKER_RUN_ARGS[@]}" bash -s < $ENABLE_SCRIPT_PATH
+
+  service_stop "$SERVICE"
+  service_start "$SERVICE"
+
+  sleep 1
+
+  # Initial backup
+  dokku_log_verbose_quiet "Creating base backup"
+
+  docker exec "$SERVICE_NAME" chown -R postgres:root /var/lib/postgresql/backups
+  docker exec -u postgres "$SERVICE_NAME" env PGPASSWORD="$PASSWORD" pg_basebackup -h localhost -U postgres -D /var/lib/postgresql/backups/base -Ft -z -P
+
+  dokku_log_verbose_quiet "WAL incremental backup enabled"
+  dokku_log_verbose_quiet "The base backup and the WAL segments are archived in $SERVICE_ROOT/backups"
+}
+
+postgres-wal-enable-cmd "$@"

--- a/subcommands/wal-recover
+++ b/subcommands/wal-recover
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_BASE_PATH/common/functions"
+source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
+
+postgres-wal-recover-cmd() {
+  [[ -z $2 ]] && dokku_log_fail "Please specify a name for the service"
+  verify_service_name "$2"
+
+  local SERVICE="$2"
+  local TIME="$3"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+  local SERVICE_NAME=$(get_service_name "$SERVICE")
+  local PASSWORD=$(cat "$SERVICE_ROOT/PASSWORD")
+  local BASE_BACKUP_HOST="$SERVICE_ROOT/backups/base/base.tar.gz"
+  local BASE_BACKUP_CONTAINER="/var/lib/postgresql/backups/base/base.tar.gz"
+  local DOCKER_RUN="docker run --rm -i -v $SERVICE_ROOT/data:/var/lib/postgresql/data -v $SERVICE_ROOT/backups:/var/lib/postgresql/backups $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION"
+
+  test -e "$SERVICE_ROOT/backups" || dokku_log_fail "No base backup available"
+
+  service_stop "$SERVICE"
+
+  dokku_log_verbose_quiet "Restoring base backup"
+
+  $DOCKER_RUN bash -c "rm -rf /var/lib/postgresql/data/*"
+  $DOCKER_RUN bash -c "cp $BASE_BACKUP_CONTAINER /var/lib/postgresql/data/"
+  $DOCKER_RUN bash -c "cd /var/lib/postgresql/data/ && tar zxf base.tar.gz"
+
+  dokku_log_verbose_quiet "Writing recovery.conf"
+  $DOCKER_RUN bash -c "echo \"restore_command = 'gunzip -c /var/lib/postgresql/backups/%f -q > %p'\" > /var/lib/postgresql/data/recovery.conf"
+
+  [[ -n $TIME ]] && dokku_log_verbose_quiet "Recover to $TIME"
+  [[ -n $TIME ]] && $DOCKER_RUN bash -c "echo \"recovery_target_time = '$TIME'\" >> /var/lib/postgresql/data/recovery.conf"
+
+  dokku_log_verbose_quiet "Restarting to start recovery"
+  service_start "$SERVICE"
+
+  dokku_log_info2 "Recovery started"
+  dokku_log_verbose_quiet "Use 'dokku $PLUGIN_COMMAND_PREFIX:logs $SERVICE -t' to monitor the progress"
+  dokku_log_verbose_quiet "It is normal to see several 'No such file or directory' messages at the "
+  dokku_log_verbose_quiet "beginning and the end of the log message. "
+}
+
+postgres-wal-recover-cmd "$@"


### PR DESCRIPTION
Implements `postgres:enable-wal <name>` that enables continuous archiving of WAL segments. This is useful as it allows incremental backup of the cluster (see http://www.postgresql.org/docs/9.1/static/continuous-archiving.html).

Archived WAL segments are written to $SERVICE_ROOT/backups, which is mounted in the container as /var/lib/postgresql/backups. User can then backup this directory on the host using traditional backup mechanisms (rsync, upload to S3, etc).

This is a feature that i have found useful in my backup workflow. Just putting it here to gauge interests of including it in the main dokku-postgres plugin. If people think this might be useful, I can polish it up, write test cases, and probably also write a command that allows streamlined recovery from archived WAL segments. 

Edit: Recover command is now implemented. See commit message of 4f57281. 
