### PR TITLE
complete sudoer file with chmod

### DIFF
--- a/install
+++ b/install
@@ -26,6 +26,7 @@ plugin-install() {
   cat > "$_SUDOERS_FILE" <<EOL
 %dokku ALL=(ALL) NOPASSWD:/bin/rm -f /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/chown root\:root /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
+%dokku ALL=(ALL) NOPASSWD:/bin/chmod 644 /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/mv ${PLUGIN_DATA_ROOT}/.TMP_CRON_FILE /etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-*
 %dokku ALL=(ALL) NOPASSWD:/bin/chown 8983 $PLUGIN_DATA_ROOT/*
 %dokku ALL=(ALL) NOPASSWD:/bin/chgrp 8983 $PLUGIN_DATA_ROOT/*


### PR DESCRIPTION
since this recent commit "Call chmod 644 on cron jobs created for scheduled backups" https://github.com/dokku/dokku-postgres/commit/c08b049c0378bdcf70c2fbbc36b840eda8c08bef when executing the dokku postgres:backup-schedule command, the root password will be prompted. This is because the chmod 644 that has been added in this fix is missing in the plugin sudoer file. Here is the fix.