### PR TITLE
add a --use-iam flag to backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
 ## commands
 
 ```
-postgres:backup <name> <bucket>   Create a backup of the postgres service to an existing s3 bucket
+postgres:backup <name> <bucket> [--use-iam]  Create a backup of the postgres service to an existing s3 bucket
 postgres:backup-auth <name> <aws_access_key_id> <aws_secret_access_key> Sets up authentication for backups on the postgres service
 postgres:backup-deauth <name>     Removes backup authentication for the postgres service
 postgres:backup-schedule <name> <schedule> <bucket> Schedules a backup of the postgres service
@@ -219,6 +219,10 @@ or root.
 Datastore backups are supported via AWS S3. The only supported region is `us-east-1`, and using an S3 bucket in another region will result in an error.
 
 > If you would like to sponsor work to enable support for other regions, please contact [@josegonzalez](http://github.com/josegonzalez/).
+
+You may skip the `backup-auth` step if your dokku install is running within EC2
+and has access to the bucket via an IAM profile. In that case, use the `--use-iam`
+option with the `backup` command.
 
 Backups can be performed using the backup commands:
 

--- a/common-functions
+++ b/common-functions
@@ -104,21 +104,26 @@ service_alternative_alias() {
 
 service_backup() {
   declare desc="Creates a backup of a service to an existing s3 bucket"
-  declare SERVICE="$1" BUCKET_NAME="$2"
+  declare SERVICE="$1" BUCKET_NAME="$2" S3_FLAG="$3"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local AWS_ACCESS_KEY_ID_FILE="$SERVICE_ROOT/backup/AWS_ACCESS_KEY_ID"
   local AWS_SECRET_ACCESS_KEY_FILE="$SERVICE_ROOT/backup/AWS_SECRET_ACCESS_KEY"
+  local AWS_VARS=""
 
-  [[ ! -f "$AWS_ACCESS_KEY_ID_FILE" ]] && dokku_log_fail "Missing AWS_ACCESS_KEY_ID file"
-  [[ ! -f "$AWS_SECRET_ACCESS_KEY_FILE" ]] && dokku_log_fail "Missing AWS_SECRET_ACCESS_KEY file"
+  if [[ -z "$S3_FLAG" ]]; then
+    [[ ! -f "$AWS_ACCESS_KEY_ID_FILE" ]] && dokku_log_fail "Missing AWS_ACCESS_KEY_ID file"
+    [[ ! -f "$AWS_SECRET_ACCESS_KEY_FILE" ]] && dokku_log_fail "Missing AWS_SECRET_ACCESS_KEY file"
+    AWS_VARS="-e AWS_ACCESS_KEY_ID=$(cat "$AWS_ACCESS_KEY_ID_FILE") -e AWS_SECRET_ACCESS_KEY=$(cat "$AWS_SECRET_ACCESS_KEY_FILE")"
+  elif [[ $S3_FLAG != "--use-iam" ]]; then
+    dokku_log_fail "Provide AWS credentials or use the --use-iam flag"
+  fi
 
   TMPDIR=$(mktemp -d)
   trap 'rm -rf "$TMPDIR" > /dev/null' RETURN INT TERM EXIT
 
   (service_export "$SERVICE" > "${TMPDIR}/export")
   docker run \
-      -e AWS_ACCESS_KEY_ID="$(cat "$AWS_ACCESS_KEY_ID_FILE")" \
-      -e AWS_SECRET_ACCESS_KEY="$(cat "$AWS_SECRET_ACCESS_KEY_FILE")" \
+      "${AWS_VARS}" \
       -e BUCKET_NAME="$BUCKET_NAME" \
       -e BACKUP_NAME="${PLUGIN_COMMAND_PREFIX}-${SERVICE}" \
       -v "${TMPDIR}:/backup" dokkupaas/s3backup:0.6.0

--- a/subcommands/backup
+++ b/subcommands/backup
@@ -7,12 +7,12 @@ source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/functions"
 postgres-backup-cmd() {
   declare desc="creates a backup of the $PLUGIN_SERVICE service to an existing s3 bucket"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup" argv=("$@"); [[ ${argv[0]} == "$cmd" ]] && shift 1
-  declare SERVICE="$1" BUCKET_NAME="$2"
+  declare SERVICE="$1" BUCKET_NAME="$2" S3_FLAG="$3"
 
   [[ -z "$SERVICE" ]] && dokku_log_fail "Please specify a name for the service"
   [[ -z "$BUCKET_NAME" ]] && dokku_log_fail "Please specify an aws bucket for the backup"
   verify_service_name "$SERVICE"
-  service_backup "$SERVICE" "$BUCKET_NAME"
+  service_backup "$SERVICE" "$BUCKET_NAME" "$S3_FLAG"
 }
 
 postgres-backup-cmd "$@"


### PR DESCRIPTION
When dokku runs on an EC2 node, it is not necessary to provide and store credentials. They are available via the EC2 metadata service automatically.