### PR TITLE
DISABLE_SSL option added (#133).

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ dokku postgres:create lolipop
 export POSTGRES_CUSTOM_ENV="USER=alpha;HOST=beta"
 dokku postgres:create lolipop
 
+# you can disable ssl if your db is accessible only internally
+export DISABLE_SSL=1
+dokku postgres:create lolipop
+
 # get connection information as follows
 dokku postgres:info lolipop
 

--- a/functions
+++ b/functions
@@ -72,7 +72,7 @@ service_create_container() {
 
 
   service_stop "$SERVICE" > /dev/null;
-  if [ -z "$DISABLE_SSL" ]; then
+  if [[ -z "$DISABLE_SSL" ]]; then
     dokku_log_verbose_quiet "Securing connection to database";
     docker run --rm -i -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s < "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &> /dev/null;
   else

--- a/functions
+++ b/functions
@@ -70,9 +70,14 @@ service_create_container() {
   DATABASE_NAME="$(get_database_name "$SERVICE")"
   docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME" 2> /dev/null || echo 'Already exists'
 
-  dokku_log_verbose_quiet "Securing connection to database"
-  service_stop "$SERVICE" > /dev/null
-  docker run --rm -i -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s < "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &> /dev/null
+
+  service_stop "$SERVICE" > /dev/null;
+  if [ -z "$DISABLE_SSL" ]; then
+    dokku_log_verbose_quiet "Securing connection to database";
+    docker run --rm -i -v "$SERVICE_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s < "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &> /dev/null;
+  else
+    dokku_log_verbose_quiet "Not securing connection to database";
+  fi
 
   PREVIOUS_ID=$(docker ps -f status=exited | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
   docker start "$PREVIOUS_ID" > /dev/null


### PR DESCRIPTION
Added. Tested:
```
root@mars:/home/dokku-postgres# DISABLE_SSL=1 dokku postgres:create lolo22
       Waiting for container to be ready
       Creating container database
       Not securing connection to database
=====> Postgres container created: lolo22
=====> Container Information
       Config dir:          /var/lib/dokku/services/postgres/lolo22/config
       Data dir:            /var/lib/dokku/services/postgres/lolo22/data
       Dsn:                 postgres://postgres:87e9f3a43ec5cc185ff1cfbf7f452c28@dokku-postgres-lolo22:5432/lolo22
       Exposed ports:       -
       Id:                  3f3bb713b67d93fe584b79692dbd6f5c8d15156c8d5432bd9c094cc5cc2aef3f
       Internal ip:         172.17.0.8
       Links:               -
       Service root:        /var/lib/dokku/services/postgres/lolo22
       Status:              running
       Version:             postgres:9.6.4
root@mars:/home/dokku-postgres#
```

And

```
root@mars:/home/dokku-postgres# dokku postgres:create lolo23
       Waiting for container to be ready
       Creating container database
       Securing connection to database
=====> Postgres container created: lolo23
=====> Container Information
       Config dir:          /var/lib/dokku/services/postgres/lolo23/config
       Data dir:            /var/lib/dokku/services/postgres/lolo23/data
       Dsn:                 postgres://postgres:ec5c2daa7e5df13bd04c8fdbea3819ac@dokku-postgres-lolo23:5432/lolo23
       Exposed ports:       -
       Id:                  389caac26ab815beb52fda011119eed62612bca6fcfc42236357815753a47c80
       Internal ip:         172.17.0.9
       Links:               -
       Service root:        /var/lib/dokku/services/postgres/lolo23
       Status:              running
       Version:             postgres:9.6.4
root@mars:/home/dokku-postgres#
```