### PR TITLE
Fix `No such container: Binary`

### DIFF
--- a/functions
+++ b/functions
@@ -81,7 +81,7 @@ service_create_container() {
   service_stop "$SERVICE" > /dev/null
   docker run --rm -i -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s < "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &> /dev/null
 
-  PREVIOUS_ID=$(docker ps -f status=exited | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
+  PREVIOUS_ID=$(docker ps -f status=exited --no-trunc | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
   docker start "$PREVIOUS_ID" > /dev/null
   service_port_unpause "$SERVICE"
 
@@ -122,14 +122,14 @@ service_start() {
   local QUIET="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local ID=$(docker ps -f status=running | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
+  local ID=$(docker ps -f status=running --no-trunc | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
   if [[ -n $ID ]]; then
     [[ -z $QUIET ]] && dokku_log_warn "Service is already started"
     return 0
   fi
 
   dokku_log_info2_quiet "Starting container"
-  local PREVIOUS_ID=$(docker ps -f status=exited | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
+  local PREVIOUS_ID=$(docker ps -f status=exited --no-trunc | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
   local IMAGE_EXISTS=$(docker images | grep -e "^$PLUGIN_IMAGE " | grep -q " $PLUGIN_IMAGE_VERSION " && true)
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 

--- a/functions
+++ b/functions
@@ -130,7 +130,6 @@ service_start() {
 
   dokku_log_info2_quiet "Starting container"
   local PREVIOUS_ID=$(docker ps -f status=exited --no-trunc | grep -e "$SERVICE_NAME$" | awk '{print $1}') || true
-  local IMAGE_EXISTS=$(docker images | grep -e "^$PLUGIN_IMAGE " | grep -q " $PLUGIN_IMAGE_VERSION " && true)
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
 
   if [[ -n $PREVIOUS_ID ]]; then


### PR DESCRIPTION
Problem earlier showed up in issue #131 but was closed due to long response time.

**Problem:**
Looks like in new Docker version
(in my case Docker version 18.06.0-ce, build 0ffa825) long commands are truncated
and sometimes can return/contain binary output (truncation `...` symbols are binary).
Because of such output `grep -e` fails to find container.

**Solution**:
Ignore `docker ps` truncation.
Workaround was to use `--no-trunc` for `docker ps` command.

I suppose similar problems could be in `redis` (https://github.com/dokku/dokku-redis/blob/master/functions#L124) and other DB plugins for dokku. If this solution will be accepted, will you be able to merge/update these plugins too?