### PR TITLE
Update upgrade instructions for newer syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ At the moment a database can’t be upgraded (or downgraded) inplace. Instead a 
 $ dokku postgres:create db9.5
 
 # Migrate it like this for example
-$ POSTGRES_IMAGE_VERSION=9.6 dokku postgres:clone db9.5 db9.6
+$ dokku postgres:clone db9.5 db9.6 -I 9.6
 
 # If it was linked to an application, first link the new DB
 $ dokku postgres:link db9.6 my_app


### PR DESCRIPTION
The old instructions no longer work - it just creates a clone with the old image version. I tried this with `--image-version` to be clearer about this, but the argument parsing seems to fall apart:

```
$ dokku postgres:clone project.9.5 project.10.4 --image-version=10.4
/var/lib/dokku/plugins/enabled/postgres/subcommands/clone: illegal option -- -
=====> Cloning toolbox to project.10.4 @ mage-version=10.4:9.5.4
/var/lib/dokku/plugins/enabled/postgres/subcommands/clone: illegal option -- -
invalid reference format
Postgres image mage-version=10.4:9.5.4 pull failed
```