### PR TITLE
feat: re-allow dashes in names

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -19,10 +19,14 @@ get_container_ip() {
 
 get_database_name() {
   declare desc="Retrieves a sanitized database name"
-  declare DATABASE="$1"
-  # some datastores do not like special characters in database names
-  # so we need to normalize them out
-  echo "$DATABASE" | tr .- _
+  declare SERVICE="$1"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+
+  if [[ ! -f "$SERVICE_ROOT/DATABASE_NAME" ]]; then
+    echo "$SERVICE" > "$SERVICE_ROOT/DATABASE_NAME"
+  fi
+
+  cat "$SERVICE_ROOT/DATABASE_NAME"
 }
 
 get_random_ports() {
@@ -89,7 +93,7 @@ is_valid_service_name() {
   declare SERVICE="$1"
   [[ -z "$SERVICE" ]] && return 1
 
-  if [[ "$SERVICE" =~ ^[A-Za-z0-9_]+$ ]]; then
+  if [[ "$SERVICE" =~ ^[A-Za-z0-9_-]+$ ]]; then
     return 0
   fi
 
@@ -779,4 +783,14 @@ verify_service_name() {
   [[ -z "$SERVICE" ]] && dokku_log_fail "(verify_service_name) SERVICE must not be null"
   [[ ! -d "$PLUGIN_DATA_ROOT/$SERVICE" ]] && dokku_log_fail "$PLUGIN_SERVICE service $SERVICE does not exist"
   return 0
+}
+
+write_database_name() {
+  declare desc="Writes a sanitized database name"
+  declare SERVICE="$1"
+  local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
+
+  # some datastores do not like special characters in database names
+  # so we need to normalize them out
+  echo "$SERVICE" | tr .- _ > "$SERVICE_ROOT/DATABASE_NAME"
 }

--- a/functions
+++ b/functions
@@ -58,6 +58,8 @@ service_create() {
   else
     echo "" >"$SERVICE_ROOT/ENV"
   fi
+
+  write_database_name "$SERVICE"
   service_create_container "$SERVICE"
 }
 
@@ -67,6 +69,7 @@ service_create_container() {
   local SERVICE_HOST_ROOT="$PLUGIN_DATA_HOST_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PREVIOUS_ID
 
   ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$PASSWORD" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
@@ -76,7 +79,6 @@ service_create_container() {
   docker run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" dokku/wait:0.3.0 -p "$PLUGIN_DATASTORE_WAIT_PORT" >/dev/null
 
   dokku_log_verbose_quiet "Creating container database"
-  DATABASE_NAME="$(get_database_name "$SERVICE")"
   docker exec "$SERVICE_NAME" su - postgres -c "createdb -E utf8 $DATABASE_NAME" 2>/dev/null || dokku_log_verbose_quiet 'Already exists'
 
   dokku_log_verbose_quiet "Securing connection to database"
@@ -148,9 +150,8 @@ service_start() {
 service_url() {
   local SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
-
-  local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
-  local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
+  local PASSWORD="$(cat "$SERVICE_ROOT/PASSWORD")"
   echo "$PLUGIN_SCHEME://postgres:$PASSWORD@$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}/$DATABASE_NAME"
 }

--- a/tests/service_create.bats
+++ b/tests/service_create.bats
@@ -7,6 +7,15 @@ load test_helper
   dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" l
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:create) service with dashes" {
+  run dokku "$PLUGIN_COMMAND_PREFIX:create" service-with-dashes
+  assert_contains "${lines[*]}" "container created: service-with-dashes"
+  assert_contains "${lines[*]}" "dokku-$PLUGIN_COMMAND_PREFIX-service-with-dashes"
+  assert_contains "${lines[*]}" "service_with_dashes"
+
+  dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-dashes
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there are no arguments" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create"
   assert_contains "${lines[*]}" "Please specify a valid name for the service"
@@ -14,8 +23,5 @@ load test_helper
 
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there is an invalid name specified" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create" d.erp
-  assert_failure
-
-  run dokku "$PLUGIN_COMMAND_PREFIX:create" d-erp
   assert_failure
 }


### PR DESCRIPTION
This PR allows dashes in service names, while still sanitizing them before they are used as database names. If the datastore is pre-existing, the datatabase name is assumed to be the same as the service name, and returned appropriately.