### PR TITLE
allows shared memory size of docker container to be adjusted

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -548,13 +548,14 @@ service_parse_args() {
       "--querystring") set -- "$@" "-q" ;;
       "--restart-apps") set -- "$@" "-R" ;;
       "--root-password") set -- "$@" "-r" ;;
+      "--shm-size") set -- "$@" "-s" ;;
       "--user") set -- "$@" "-u" ;;
       *) set -- "$@" "$arg" ;;
     esac
   done
 
   OPTIND=1
-  while getopts "a:c:C:d:i:I:m:p:q:R:r:u:" opt; do
+  while getopts "a:c:C:d:i:I:m:p:q:R:r:s:u:" opt; do
     case "$opt" in
       a)
         SERVICE_ALIAS="${OPTARG^^}"
@@ -589,6 +590,9 @@ service_parse_args() {
         ;;
       r)
         export SERVICE_ROOT_PASSWORD=$OPTARG
+        ;;
+      s)
+        export SERVICE_SHM_SIZE=$OPTARG
         ;;
       u)
         export SERVICE_USER=$OPTARG

--- a/functions
+++ b/functions
@@ -68,11 +68,12 @@ service_create_container() {
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_HOST_ROOT="$PLUGIN_DATA_HOST_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
+  local SHM_SIZE="${SERVICE_SHM_SIZE:="64m"}"
   local PASSWORD="$(service_password "$SERVICE")"
   local DATABASE_NAME="$(get_database_name "$SERVICE")"
   local PREVIOUS_ID
 
-  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$PASSWORD" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+  ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" -e "POSTGRES_PASSWORD=$PASSWORD" --shm-size="$SHM_SIZE" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=postgres "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
   echo "$ID" >"$SERVICE_ROOT/ID"
 
   dokku_log_verbose_quiet "Waiting for container to be ready"

--- a/subcommands/clone
+++ b/subcommands/clone
@@ -15,6 +15,7 @@ service-clone-cmd() {
   #F -I|--image-version IMAGE_VERSION, the image version to start the service with
   #F -p|--password PASSWORD, override the user-level service password
   #F -r|--root-password PASSWORD, override the root-level service password
+  #F -s|--shm-size SHM_SIZE, override shared memory size for postgres docker container (defaults to 64m)
   declare desc="create container <new-name> then copy data from <name> into <new-name>"
   local cmd="$PLUGIN_COMMAND_PREFIX:clone" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1

--- a/subcommands/create
+++ b/subcommands/create
@@ -23,6 +23,7 @@ service-create-cmd() {
   #F -I|--image-version IMAGE_VERSION, the image version to start the service with
   #F -p|--password PASSWORD, override the user-level service password
   #F -r|--root-password PASSWORD, override the root-level service password
+  #F -s|--shm-size SHM_SIZE, override shared memory size for postgres docker container (defaults to 64m)
   declare desc="create a $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:create" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1

--- a/tests/service_create.bats
+++ b/tests/service_create.bats
@@ -16,6 +16,15 @@ load test_helper
   dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" service-with-dashes
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:create) service with changed shm size" {
+  run dokku "$PLUGIN_COMMAND_PREFIX:create" foobar-256 --shm-size="256m"
+  run docker exec -it dokku.postgres.foobar-256 df -h /dev/shm
+  assert_contains "${lines[*]}" "shm"
+  assert_contains "${lines[*]}" "256M"
+
+  dokku --force "$PLUGIN_COMMAND_PREFIX:destroy" foobar-256
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:create) error when there are no arguments" {
   run dokku "$PLUGIN_COMMAND_PREFIX:create"
   assert_contains "${lines[*]}" "Please specify a valid name for the service"


### PR DESCRIPTION
sometimes postgres needs more shared memory than the defaulting 64m docker allows. this gives the option to adjust the shared memory size.

regarding tests: we were not able to run them locally etc. so they might need some love. 

