### PR TITLE
Allow specifying DB for export

### DIFF
--- a/functions
+++ b/functions
@@ -97,7 +97,7 @@ service_export() {
   local SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
-  local DATABASE_NAME="$(get_database_name "$SERVICE")"
+  local DATABASE_NAME="${2:-$(get_database_name "$SERVICE")}"
   local PASSWORD="$(service_password "$SERVICE")"
 
   [[ -n $SSH_TTY ]] && stty -opost
@@ -118,7 +118,7 @@ service_import() {
   if [[ -t 0 ]]; then
     dokku_log_fail "No data provided on stdin."
   fi
-  docker exec -i "$SERVICE_NAME" env PGPASSWORD="$PASSWORD" pg_restore -h localhost -cO --if-exists -d "$DATABASE_NAME" -U postgres -w
+  docker exec -i "$SERVICE_NAME" env PGPASSWORD="$PASSWORD" pg_restore -h localhost -cO --if-exists -C -d "$DATABASE_NAME" -U postgres -w
 }
 
 service_start() {

--- a/subcommands/clone
+++ b/subcommands/clone
@@ -37,7 +37,13 @@ service-clone-cmd() {
   dokku_log_info2 "Cloning $SERVICE to $NEW_SERVICE @ $PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION"
   service_create "$NEW_SERVICE" "${@:3}"
   dokku_log_info1 "Copying data from $SERVICE to $NEW_SERVICE"
-  service_export "$SERVICE" | service_import "$NEW_SERVICE" >/dev/null 2>&1 || true
+  for DATABASE_NAME in $(docker exec dokku.postgres.td1 psql -qtA -U postgres -c "SELECT datname FROM pg_catalog.pg_database;"); do
+    if [[ $DATABASE_NAME == "postgres" || $DATABASE_NAME == "template0" ]]; then
+      continue
+    fi
+    service_export "$SERVICE" "$DATABASE_NAME" | service_import "$NEW_SERVICE" "$DATABASE_NAME">/dev/null 2>&1 || true
+
+  done
   dokku_log_info2 "Done"
 }
 

--- a/subcommands/export
+++ b/subcommands/export
@@ -15,11 +15,12 @@ service-export-cmd() {
   local cmd="$PLUGIN_COMMAND_PREFIX:export" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"
+  declare DATABASE_NAME="$2"
   is_implemented_command "$cmd" || dokku_log_fail "Not yet implemented"
 
   [[ -z "$SERVICE" ]] && dokku_log_fail "Please specify a valid name for the service"
   verify_service_name "$SERVICE"
-  service_export "$SERVICE"
+  service_export "$SERVICE" "$DATABASE_NAME"
 }
 
 service-export-cmd "$@"


### PR DESCRIPTION
:sparkles: Allow specifying DB for export
:sparkles: Actually clone the service, not just the SERVICE_NAME DB
See #180