### PR TITLE
make tense in command descriptions more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ sudo dokku plugin:install https://github.com/dokku/dokku-postgres.git postgres
 
 ```
 postgres:app-links <app>                           # list all postgres service links for a given app
-postgres:backup <service> <bucket-name> [--use-iam] # creates a backup of the postgres service to an existing s3 bucket
-postgres:backup-auth <service> <aws-access-key-id> <aws-secret-access-key> <aws-default-region> <aws-signature-version> <endpoint-url> # sets up authentication for backups on the postgres service
-postgres:backup-deauth <service>                   # removes backup authentication for the postgres service
-postgres:backup-schedule <service> <schedule> <bucket-name> [--use-iam] # schedules a backup of the postgres service
+postgres:backup <service> <bucket-name> [--use-iam] # create a backup of the postgres service to an existing s3 bucket
+postgres:backup-auth <service> <aws-access-key-id> <aws-secret-access-key> <aws-default-region> <aws-signature-version> <endpoint-url> # set up authentication for backups on the postgres service
+postgres:backup-deauth <service>                   # remove backup authentication for the postgres service
+postgres:backup-schedule <service> <schedule> <bucket-name> [--use-iam] # schedule a backup of the postgres service
 postgres:backup-schedule-cat <service>             # cat the contents of the configured backup cronfile for the service
-postgres:backup-set-encryption <service> <passphrase> # sets encryption for all future backups of postgres service
-postgres:backup-unschedule <service>               # unschedules the backup of the postgres service
-postgres:backup-unset-encryption <service>         # unsets encryption for future backups of the postgres service
+postgres:backup-set-encryption <service> <passphrase> # set encryption for all future backups of postgres service
+postgres:backup-unschedule <service>               # unschedule the backup of the postgres service
+postgres:backup-unset-encryption <service>         # unset encryption for future backups of the postgres service
 postgres:clone <service> <new-service> [--clone-flags...] # create container <new-name> then copy data from <name> into <new-name>
 postgres:connect <service>                         # connect to the service via the postgres connection tool
 postgres:create <service> [--create-flags...]      # create a postgres service
@@ -522,7 +522,7 @@ You may skip the `backup-auth` step if your dokku install is running within EC2 
 
 Backups can be performed using the backup commands:
 
-### sets up authentication for backups on the postgres service
+### set up authentication for backups on the postgres service
 
 ```shell
 # usage
@@ -553,7 +553,7 @@ More specific example for minio auth:
 dokku postgres:backup-auth lolipop MINIO_ACCESS_KEY_ID MINIO_SECRET_ACCESS_KEY us-east-1 s3v4 https://YOURMINIOSERVICE
 ```
 
-### removes backup authentication for the postgres service
+### remove backup authentication for the postgres service
 
 ```shell
 # usage
@@ -566,7 +566,7 @@ Remove s3 authentication:
 dokku postgres:backup-deauth lolipop
 ```
 
-### creates a backup of the postgres service to an existing s3 bucket
+### create a backup of the postgres service to an existing s3 bucket
 
 ```shell
 # usage
@@ -589,7 +589,7 @@ Restore a backup file (assuming it was extracted via `tar -xf backup.tgz`):
 dokku postgres:import lolipop < backup-folder/export
 ```
 
-### sets encryption for all future backups of postgres service
+### set encryption for all future backups of postgres service
 
 ```shell
 # usage
@@ -602,7 +602,7 @@ Set the GPG-compatible passphrase for encrypting backups for backups:
 dokku postgres:backup-set-encryption lolipop
 ```
 
-### unsets encryption for future backups of the postgres service
+### unset encryption for future backups of the postgres service
 
 ```shell
 # usage
@@ -615,7 +615,7 @@ Unset the `GPG` encryption passphrase for backups:
 dokku postgres:backup-unset-encryption lolipop
 ```
 
-### schedules a backup of the postgres service
+### schedule a backup of the postgres service
 
 ```shell
 # usage
@@ -653,7 +653,7 @@ Cat the contents of the configured backup cronfile for the service:
 dokku postgres:backup-schedule-cat lolipop
 ```
 
-### unschedules the backup of the postgres service
+### unschedule the backup of the postgres service
 
 ```shell
 # usage

--- a/common-functions
+++ b/common-functions
@@ -5,7 +5,7 @@ set -eo pipefail
 source "$PLUGIN_AVAILABLE_PATH/config/functions"
 
 docker_ports_options() {
-  declare desc="Exports a list of exposed ports"
+  declare desc="export a list of exposed ports"
   declare PORTS=("$@")
   for ((i = 0; i < ${#PLUGIN_DATASTORE_PORTS[@]}; i++)); do
     echo -n "-p ${PORTS[i]}:${PLUGIN_DATASTORE_PORTS[i]} "
@@ -13,13 +13,13 @@ docker_ports_options() {
 }
 
 get_container_ip() {
-  declare desc="Retrieves the ip address of a container"
+  declare desc="retrieve the ip address of a container"
   declare CONTAINER_ID="$1"
   docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$CONTAINER_ID" 2>/dev/null
 }
 
 get_database_name() {
-  declare desc="Retrieves a sanitized database name"
+  declare desc="retrieve a sanitized database name"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
 
@@ -31,7 +31,7 @@ get_database_name() {
 }
 
 get_random_ports() {
-  declare desc="Retrieves N random ports"
+  declare desc="retrieve N random ports"
   declare iterations="${1:-1}"
   for ((i = 0; i < iterations; i++)); do
     local port=$RANDOM
@@ -50,19 +50,19 @@ get_random_ports() {
 }
 
 get_service_name() {
-  declare desc="Retrieves a docker service label"
+  declare desc="retrieve a docker service label"
   declare SERVICE="$1"
   echo "dokku.${PLUGIN_COMMAND_PREFIX}.$SERVICE"
 }
 
 get_url_from_config() {
-  declare desc="Retrieves a given _URL from a list of configuration variables"
+  declare desc="retrieve a given _URL from a list of configuration variables"
   declare EXISTING_CONFIG="$1" CONFIG_VAR="$2"
   echo "$EXISTING_CONFIG" | grep "$CONFIG_VAR" | sed "s/$CONFIG_VAR:\s*//" | xargs
 }
 
 is_container_status() {
-  declare desc="Returns 0 or 1 depending upon whether a given container has a certain status"
+  declare desc="return 0 or 1 depending upon whether a given container has a certain status"
   declare CID="$1" STATUS="$2"
   local TEMPLATE="{{.State.$STATUS}}"
   local CONTAINER_STATUS=$(docker inspect -f "$TEMPLATE" "$CID" 2>/dev/null || true)
@@ -90,7 +90,7 @@ is_implemented_command() {
 }
 
 is_valid_service_name() {
-  declare desc="Validates a service name"
+  declare desc="validate a service name"
   declare SERVICE="$1"
   [[ -z "$SERVICE" ]] && return 1
 
@@ -102,7 +102,7 @@ is_valid_service_name() {
 }
 
 remove_from_links_file() {
-  declare desc="Removes an app from the service link file"
+  declare desc="remove an app from the service link file"
   declare SERVICE="$1" APP="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local LINKS_FILE="$SERVICE_ROOT/LINKS"
@@ -137,7 +137,7 @@ retry-docker-command() {
 }
 
 service_alternative_alias() {
-  declare desc="Retrieves an alternative alias for a service"
+  declare desc="retrieve an alternative alias for a service"
   declare EXISTING_CONFIG="$1"
   local COLORS=(AQUA BLACK BLUE FUCHSIA GRAY GREEN LIME MAROON NAVY OLIVE PURPLE RED SILVER TEAL WHITE YELLOW)
   local ALIAS
@@ -154,7 +154,7 @@ service_alternative_alias() {
 }
 
 service_app_links() {
-  declare desc="Outputs all service links for a given app"
+  declare desc="output all service links for a given app"
   declare APP="$1"
   local SERVICE LINKED_APP
 
@@ -170,7 +170,7 @@ service_app_links() {
 }
 
 service_backup() {
-  declare desc="Creates a backup of a service to an existing s3 bucket"
+  declare desc="create a backup of a service to an existing s3 bucket"
   declare SERVICE="$1" BUCKET_NAME="$2" USE_IAM_OPTIONAL_FLAG="$3"
   local SERVICE_BACKUP_ROOT="$PLUGIN_DATA_ROOT/$SERVICE/backup"
   local BACKUP_ENCRYPTION_CONFIG_ROOT="$PLUGIN_DATA_ROOT/$SERVICE/backup-encryption"
@@ -250,7 +250,7 @@ service_commit_config() {
 }
 
 service_backup_auth() {
-  declare desc="Sets up authentication"
+  declare desc="set up authentication"
   declare SERVICE="$1" AWS_ACCESS_KEY_ID="$2" AWS_SECRET_ACCESS_KEY="$3" AWS_DEFAULT_REGION="$4" AWS_SIGNATURE_VERSION="$5" ENDPOINT_URL="$6"
   local SERVICE_BACKUP_ROOT="$PLUGIN_DATA_ROOT/$SERVICE/backup"
 
@@ -272,7 +272,7 @@ service_backup_auth() {
 }
 
 service_backup_deauth() {
-  declare desc="Removes authentication"
+  declare desc="remove authentication"
   declare SERVICE="$1"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ROOT="${SERVICE_ROOT}/backup/"
@@ -310,7 +310,7 @@ service_backup_schedule_cat() {
 }
 
 service_backup_set_encryption() {
-  declare desc="Sets up backup encryption"
+  declare desc="set up backup encryption"
   declare SERVICE="$1" ENCRYPTION_KEY="$2"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
@@ -320,7 +320,7 @@ service_backup_set_encryption() {
 }
 
 service_backup_unschedule() {
-  declare desc="unschedules the backup of the service"
+  declare desc="unschedule the backup of the service"
   declare SERVICE="$1"
   local CRON_FILE="/etc/cron.d/dokku-${PLUGIN_COMMAND_PREFIX}-${SERVICE}"
 
@@ -328,7 +328,7 @@ service_backup_unschedule() {
 }
 
 service_backup_unset_encryption() {
-  declare desc="Removes backup encryption"
+  declare desc="remove backup encryption"
   declare SERVICE="$1"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
@@ -337,7 +337,7 @@ service_backup_unset_encryption() {
 }
 
 service_container_rm() {
-  declare desc="Stops a service and removes the running container"
+  declare desc="stop a service and remove the running container"
   declare SERVICE="$1"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local ID
@@ -357,14 +357,14 @@ service_container_rm() {
 }
 
 service_dns_hostname() {
-  declare desc="Retrieves the alias of a service"
+  declare desc="retrieve the alias of a service"
   declare SERVICE="$1"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   echo "$SERVICE_NAME" | tr ._ -
 }
 
 service_enter() {
-  declare desc="enters running app container of specified proc type"
+  declare desc="enter running app container of specified proc type"
   declare SERVICE="$1" && shift 1
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ID="$(cat "$SERVICE_ROOT/ID")"
@@ -379,7 +379,7 @@ service_enter() {
 }
 
 service_exposed_ports() {
-  declare desc="Lists exposed ports for a service"
+  declare desc="list exposed ports for a service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local PORT_FILE="$SERVICE_ROOT/PORT"
@@ -391,7 +391,7 @@ service_exposed_ports() {
 }
 
 service_image_exists() {
-  declare desc="Checks if the current image exists"
+  declare desc="check if the current image exists"
   local IMAGE="$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION"
 
   if [[ "$(docker images -q "$IMAGE" 2>/dev/null)" == "" ]]; then
@@ -402,7 +402,7 @@ service_image_exists() {
 }
 
 service_info() {
-  declare desc="Retrieves information about a given service"
+  declare desc="retrieve information about a given service"
   declare SERVICE="$1" INFO_FLAG="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_URL=$(service_url "$SERVICE")
@@ -442,7 +442,7 @@ service_info() {
 }
 
 service_is_linked() {
-  declare desc="Links a service to an application"
+  declare desc="link a service to an application"
   declare SERVICE="$1" APP="$2"
   update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
@@ -456,7 +456,7 @@ service_is_linked() {
 }
 
 service_link() {
-  declare desc="Links a service to an application"
+  declare desc="link a service to an application"
   declare SERVICE="$1" APP="$2"
   update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
@@ -501,7 +501,7 @@ service_link() {
 }
 
 service_linked_apps() {
-  declare desc="Lists all apps linked to a service for info output"
+  declare desc="list all apps linked to a service for info output"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local LINKS_FILE="$SERVICE_ROOT/LINKS"
@@ -513,7 +513,7 @@ service_linked_apps() {
 }
 
 service_links() {
-  declare desc="Lists all apps linked to a service"
+  declare desc="list all apps linked to a service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local LINKS_FILE="$SERVICE_ROOT/LINKS"
@@ -525,7 +525,7 @@ service_links() {
 }
 
 service_list() {
-  declare desc="Lists all services and their status"
+  declare desc="list all services and their status"
   local SERVICES=$(ls "$PLUGIN_DATA_ROOT" 2>/dev/null)
 
   if [[ -z $SERVICES ]]; then
@@ -540,7 +540,7 @@ service_list() {
 }
 
 service_logs() {
-  declare desc="Displays logs for a service"
+  declare desc="display logs for a service"
   declare SERVICE="$1" TAIL_FLAG="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ID=$(cat "$SERVICE_ROOT/ID")
@@ -629,7 +629,7 @@ service_parse_args() {
 }
 
 service_password() {
-  declare desc="Fetch the password for a service"
+  declare desc="fetch the password for a service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local PASSWORD_FILE="$SERVICE_ROOT/PASSWORD"
@@ -639,7 +639,7 @@ service_password() {
 }
 
 service_root_password() {
-  declare desc="Fetch the root password for a service"
+  declare desc="fetch the root password for a service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local PASSWORD_FILE="$SERVICE_ROOT/ROOTPASSWORD"
@@ -649,14 +649,14 @@ service_root_password() {
 }
 
 service_port_expose() {
-  declare desc="Wrapper for exposing service ports"
+  declare desc="wrapper for exposing service ports"
   declare SERVICE="$1"
   service_start "$SERVICE" "true"
   service_port_unpause "$SERVICE" "true" "${@:2}"
 }
 
 service_port_pause() {
-  declare desc="Pauses service exposure"
+  declare desc="pause service exposure"
   declare SERVICE="$1" LOG_FAIL="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local EXPOSED_NAME="$(get_service_name "$SERVICE").ambassador"
@@ -686,7 +686,7 @@ service_port_pause() {
 }
 
 service_port_unexpose() {
-  declare desc="Wrapper for pausing exposed service ports"
+  declare desc="wrapper for pausing exposed service ports"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local PORT_FILE="$SERVICE_ROOT/PORT"
@@ -695,7 +695,7 @@ service_port_unexpose() {
 }
 
 service_port_unpause() {
-  declare desc="Starts service exposure"
+  declare desc="start service exposure"
   declare SERVICE="$1" LOG_FAIL="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
@@ -726,7 +726,7 @@ service_port_unpause() {
 }
 
 service_promote() {
-  declare desc="Promotes a secondary service to the primary env var"
+  declare desc="promote a secondary service to the primary env var"
   declare SERVICE="$1" APP="$2"
   local PLUGIN_DEFAULT_CONFIG_VAR="${PLUGIN_DEFAULT_ALIAS}_URL"
   local EXISTING_CONFIG=$(config_all "$APP")
@@ -754,7 +754,7 @@ service_promote() {
 }
 
 service_set_alias() {
-  declare desc="Sets the alias in use for a service"
+  declare desc="sets the alias in use for a service"
   declare SERVICE="$1" ALIAS="$2"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ALIAS_FILE="$SERVICE_ROOT/ALIAS"
@@ -764,7 +764,7 @@ service_set_alias() {
 }
 
 service_status() {
-  declare desc="Displays the status of a service"
+  declare desc="display the status of a service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local ID="$(cat "$SERVICE_ROOT/ID")"
@@ -776,7 +776,7 @@ service_status() {
 }
 
 service_stop() {
-  declare desc="Stops a running service"
+  declare desc="stop a running service"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
@@ -794,7 +794,7 @@ service_stop() {
 }
 
 service_unlink() {
-  declare desc="Unlinks an application from a service"
+  declare desc="unlink an application from a service"
   declare SERVICE="$1" APP="$2"
   update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
@@ -821,14 +821,14 @@ service_unlink() {
 }
 
 service_version() {
-  declare desc="Displays the running version for an image"
+  declare desc="display the running version for an image"
   declare SERVICE="$1"
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   docker inspect -f '{{.Config.Image}}' "$SERVICE_NAME" 2>/dev/null || true
 }
 
 update_plugin_scheme_for_app() {
-  declare desc="Retrieves the updated plugin scheme"
+  declare desc="retrieve the updated plugin scheme"
   declare APP="$1"
   local DATABASE_SCHEME
 
@@ -837,7 +837,7 @@ update_plugin_scheme_for_app() {
 }
 
 verify_service_name() {
-  declare desc="Verifies that a service exists"
+  declare desc="verify that a service exists"
   declare SERVICE="$1"
   [[ -z "$SERVICE" ]] && dokku_log_fail "(verify_service_name) SERVICE must not be null"
   [[ ! -d "$PLUGIN_DATA_ROOT/$SERVICE" ]] && dokku_log_fail "$PLUGIN_SERVICE service $SERVICE does not exist"
@@ -845,7 +845,7 @@ verify_service_name() {
 }
 
 write_database_name() {
-  declare desc="Writes a sanitized database name"
+  declare desc="write a sanitized database name"
   declare SERVICE="$1"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
 

--- a/help-functions
+++ b/help-functions
@@ -141,7 +141,7 @@ fn-help-contents-subcommand() {
 }
 
 fn-help-fancy-tput() {
-  declare desc="A wrapper around tput"
+  declare desc="a wrapper around tput"
 
   if [[ -n "$DOKKU_NO_COLOR" ]] || [[ "$TERM" == "unknown" ]] || [[ "$TERM" == "dumb" ]]; then
     return
@@ -151,7 +151,7 @@ fn-help-fancy-tput() {
 }
 
 fn-help-fancy-color() {
-  declare desc="A wrapper around colors"
+  declare desc="a wrapper around colors"
 
   if [[ -n "$DOKKU_NO_COLOR" ]] || [[ "$TERM" == "unknown" ]] || [[ "$TERM" == "dumb" ]]; then
     return
@@ -309,7 +309,7 @@ fn-help-subcommand-sanitize() {
 }
 
 _fn-help-apply-shell-expansion() {
-  declare desc="Expand environment variables for a shell command"
+  declare desc="expand environment variables for a shell command"
   declare data="$1"
   declare delimiter="__apply_shell_expansion_delimiter__"
   declare command="cat <<$delimiter"$'\n'"$data"$'\n'"$delimiter"

--- a/subcommands/backup
+++ b/subcommands/backup
@@ -13,7 +13,7 @@ service-backup-cmd() {
   #F -u|--use-iam, use the IAM profile associated with the current server
   #A service, service to run command against
   #A bucket-name, name of the s3 bucket to upload backups to
-  declare desc="creates a backup of the $PLUGIN_SERVICE service to an existing s3 bucket"
+  declare desc="create a backup of the $PLUGIN_SERVICE service to an existing s3 bucket"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1" BUCKET_NAME="$2" USE_IAM_OPTIONAL_FLAG="$3"

--- a/subcommands/backup-auth
+++ b/subcommands/backup-auth
@@ -20,7 +20,7 @@ service-backup-auth-cmd() {
   #A aws-default-region, (optional) a valid amazon S3 region
   #A aws-signature-version, (optional) the AWS signature version to use when signing S3 requests
   #A endpoint-url, (optional) an aws endpoint to upload to
-  declare desc="sets up authentication for backups on the $PLUGIN_SERVICE service"
+  declare desc="set up authentication for backups on the $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-auth" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1" AWS_ACCESS_KEY_ID="$2" AWS_SECRET_ACCESS_KEY="$3" AWS_DEFAULT_REGION="$4" AWS_SIGNATURE_VERSION="$5" ENDPOINT_URL="$6"

--- a/subcommands/backup-deauth
+++ b/subcommands/backup-deauth
@@ -9,7 +9,7 @@ service-backup-deauth-cmd() {
   #E remove s3 authentication
   #E dokku $PLUGIN_COMMAND_PREFIX:backup-deauth lolipop
   #A service, service to run command against
-  declare desc="removes backup authentication for the $PLUGIN_SERVICE service"
+  declare desc="remove backup authentication for the $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-deauth" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"

--- a/subcommands/backup-schedule
+++ b/subcommands/backup-schedule
@@ -15,7 +15,7 @@ service-backup-schedule-cmd() {
   #A service, service to run command against
   #A schedule, a cron schedule to run backups on
   #A bucket-name, name of the s3 bucket to upload backups to
-  declare desc="schedules a backup of the $PLUGIN_SERVICE service"
+  declare desc="schedule a backup of the $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-schedule" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1" SCHEDULE="$2" BUCKET_NAME="$3" USE_IAM_OPTIONAL_FLAG="$4"

--- a/subcommands/backup-set-encryption
+++ b/subcommands/backup-set-encryption
@@ -10,7 +10,7 @@ service-backup-set-encryption-cmd() {
   #E dokku $PLUGIN_COMMAND_PREFIX:backup-set-encryption lolipop
   #A service, service to run command against
   #A passphrase, a GPG-compatible passphrase
-  declare desc="sets encryption for all future backups of $PLUGIN_SERVICE service"
+  declare desc="set encryption for all future backups of $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-set-encryption" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1" PASSPHRASE="$2"

--- a/subcommands/backup-unschedule
+++ b/subcommands/backup-unschedule
@@ -9,7 +9,7 @@ service-backup-unschedule-cmd() {
   #E remove the scheduled backup from cron
   #E dokku $PLUGIN_COMMAND_PREFIX:backup-unschedule lolipop
   #A service, service to run command against
-  declare desc="unschedules the backup of the $PLUGIN_SERVICE service"
+  declare desc="unschedule the backup of the $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-unschedule" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"

--- a/subcommands/backup-unset-encryption
+++ b/subcommands/backup-unset-encryption
@@ -9,7 +9,7 @@ service-backup-unset-encryption-cmd() {
   #E unset the GPG encryption passphrase for backups
   #E dokku $PLUGIN_COMMAND_PREFIX:backup-unset-encryption lolipop
   #A service, service to run command against
-  declare desc="unsets encryption for future backups of the $PLUGIN_SERVICE service"
+  declare desc="unset encryption for future backups of the $PLUGIN_SERVICE service"
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-unset-encryption" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"


### PR DESCRIPTION
I noticed in the README:

- export a dump of the postgres service database
- sets up authentication for backups on the postgres service

The tense of these is inconsistent between `export` and `sets`. I went through the `desc` of commands and functions and made them the first style.