### PR TITLE
Extend server certificate validity to 1000 years

### DIFF
--- a/scripts/enable_ssl.sh
+++ b/scripts/enable_ssl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 pushd /var/lib/postgresql/data >/dev/null
-openssl req -new -newkey rsa:4096 -x509 -nodes -out server.crt -keyout server.key -batch
+openssl req -new -newkey rsa:4096 -x509 -days 365000 -nodes -out server.crt -keyout server.key -batch
 chmod 600 server.key
 sed -i "s/^#ssl = off/ssl = on/" postgresql.conf
 sed -i "s/^#ssl_ciphers =.*/ssl_ciphers = 'AES256+EECDH:AES256+EDH'/" postgresql.conf


### PR DESCRIPTION
It is a self-signed, therefore not providing authentication, only traffic encryption.
The default validity (30 days) is too short.
As there is no auto-renewal mechanism, a longer default period is appropriate.