### PR TITLE
fix: create ssl certs outside container

### DIFF
--- a/functions
+++ b/functions
@@ -98,7 +98,9 @@ service_create_container() {
 
   dokku_log_verbose_quiet "Securing connection to database"
   service_stop "$SERVICE" >/dev/null
-  docker run --rm -i -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s <"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &>/dev/null
+  "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/create_ssl_certs.sh" "$SERVICE_HOST_ROOT" &>/dev/null
+  docker run --rm -i -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" -v "$SERVICE_HOST_ROOT/certs:/var/lib/postgresql/certs" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s <"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &>/dev/null
+  rm -rf "$SERVICE_HOST_ROOT/certs"
 
   PREVIOUS_ID=$(docker ps -aq --no-trunc --filter "status=exited" --filter "name=^/$SERVICE_NAME$" --format '{{ .ID }}') || true
   docker start "$PREVIOUS_ID" >/dev/null

--- a/scripts/create_ssl_certs.sh
+++ b/scripts/create_ssl_certs.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+postgres_service_dir="$1"
+
+cd "$postgres_service_dir"
+mkdir certs && cd certs
+openssl req -new -newkey rsa:4096 -x509 -days 365000 -nodes -out server.crt -keyout server.key -batch

--- a/scripts/enable_ssl.sh
+++ b/scripts/enable_ssl.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
-pushd /var/lib/postgresql/data >/dev/null
-openssl req -new -newkey rsa:4096 -x509 -days 365000 -nodes -out server.crt -keyout server.key -batch
+#!/bin/sh
+
+cd /var/lib/postgresql/data
+
+cp ../certs/* .
+chown postgres:postgres server.key
 chmod 600 server.key
+
 sed -i "s/^#ssl = off/ssl = on/" postgresql.conf
 sed -i "s/^#ssl_ciphers =.*/ssl_ciphers = 'AES256+EECDH:AES256+EDH'/" postgresql.conf
-popd >/dev/null


### PR DESCRIPTION
This enables support for alpine-based images like timescaledb (no bash/openssl).

Fixes #153
Fixes timescale/timescaledb-docker#99