### PR TITLE
Fix postgres:create when running inside a docker container

### DIFF
--- a/functions
+++ b/functions
@@ -149,7 +149,7 @@ service_create_container() {
 
   dokku_log_verbose_quiet "Securing connection to database"
   service_pause "$SERVICE" >/dev/null
-  "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/create_ssl_certs.sh" "$SERVICE_HOST_ROOT" &>/dev/null
+  "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/create_ssl_certs.sh" "$SERVICE_ROOT" &>/dev/null
   "$DOCKER_BIN" container run --rm -i -v "$SERVICE_HOST_ROOT/data:/var/lib/postgresql/data" -v "$SERVICE_HOST_ROOT/certs:/var/lib/postgresql/certs" "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION" bash -s <"$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/enable_ssl.sh" &>/dev/null
   rm -rf "$SERVICE_HOST_ROOT/certs"
 

--- a/scripts/create_ssl_certs.sh
+++ b/scripts/create_ssl_certs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 postgres_service_dir="$1"
 
 cd "$postgres_service_dir"

--- a/scripts/enable_ssl.sh
+++ b/scripts/enable_ssl.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 cd /var/lib/postgresql/data
 
 cp ../certs/* .


### PR DESCRIPTION
This fixes #299 

When running the command `dokku postgres:create [some_name]` from dokku installed inside docker, the command failed (silently), since it points to the host directory instead of the one inside the container.

I've switched from `SERVICE_HOST_ROOT` to `SERVICE_ROOT` when running `create_ssl_certs.sh`

I've also put a `set -e` in the creation scripts to improve debugging.
