### PR TITLE
fix: set ON_ERROR_STOP=1 for psql, so calling scripts get an exit status

### DIFF
--- a/functions
+++ b/functions
@@ -18,7 +18,7 @@ service_connect() {
   local SERVICE_TTY_OPTS
   has_tty && SERVICE_TTY_OPTS="-t"
 
-  "$DOCKER_BIN" container exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" psql -h localhost -U postgres "$DATABASE_NAME"
+  "$DOCKER_BIN" container exec --env=LANG=C.UTF-8 --env=LC_ALL=C.UTF-8 -i $SERVICE_TTY_OPTS "$SERVICE_NAME" psql -v ON_ERROR_STOP=1 -h localhost -U postgres "$DATABASE_NAME"
 }
 
 service_create() {


### PR DESCRIPTION
Currently, using `postgres:connect` with a script passed in through stdin, there is no way to know if the script failed or not.

This change aligns the behavior with https://github.com/docker-library/postgres/blob/eaa1c35769621a6bb1e499073a5812ba478c7688/docker-entrypoint.sh#L196 which returns an exit status.