### PR TITLE
Fixed the backup-unset-public-key-encryption command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,6 +646,10 @@ Datastore backups are supported via AWS S3 and S3 compatible services like [mini
 
 You may skip the `backup-auth` step if your dokku install is running within EC2 and has access to the bucket via an IAM profile. In that case, use the `--use-iam` option with the `backup` command.
 
+If both passphrase and public key forms of encryption are set, the public key encryption will take precedence.
+
+The underlying core backup script is present [here](https://github.com/dokku/docker-s3backup/blob/main/backup.sh).
+
 Backups can be performed using the backup commands:
 
 ### set up authentication for backups on the postgres service
@@ -728,7 +732,11 @@ Set the GPG-compatible passphrase for encrypting backups for backups:
 dokku postgres:backup-set-encryption lollipop
 ```
 
+Public key encryption will take precendence over the passphrase encryption if both types are set.
+
 ### set GPG Public Key encryption for all future backups of postgres service
+
+This method currently requires the <public-key-id> to be present on the "keyserver.ubuntu.com" keyserver.
 
 ```shell
 # usage
@@ -740,6 +748,8 @@ Set the `GPG` Public Key for encrypting backups:
 ```shell
 dokku postgres:backup-set-public-key-encryption lollipop
 ```
+
+This will take precendence over the passphrase encryption.
 
 ### unset encryption for future backups of the postgres service
 

--- a/common-functions
+++ b/common-functions
@@ -433,7 +433,7 @@ service_backup_set_encryption() {
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  mkdir "$SERVICE_BACKUP_ENCRYPTION_ROOT"
+  mkdir -p "$SERVICE_BACKUP_ENCRYPTION_ROOT"
   echo "$ENCRYPTION_KEY" >"${SERVICE_BACKUP_ENCRYPTION_ROOT}/ENCRYPTION_KEY"
 }
 
@@ -443,7 +443,7 @@ service_backup_set_public_key_encryption() {
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  mkdir "$SERVICE_BACKUP_ENCRYPTION_ROOT"
+  mkdir -p "$SERVICE_BACKUP_ENCRYPTION_ROOT"
   echo "$ENCRYPT_WITH_PUBLIC_KEY_ID" >"${SERVICE_BACKUP_ENCRYPTION_ROOT}/ENCRYPT_WITH_PUBLIC_KEY_ID"
 }
 
@@ -461,16 +461,16 @@ service_backup_unset_encryption() {
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  rm -rf "$SERVICE_BACKUP_ENCRYPTION_ROOT"
+  rm "$SERVICE_BACKUP_ENCRYPTION_ROOT/ENCRYPTION_KEY"
 }
 
-service_backup_unset_encryption() {
-  declare desc="remove backup encryption"
+service_backup_unset_public_key_encryption() {
+  declare desc="remove backup GPG Public Key encryption"
   declare SERVICE="$1"
   local SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
   local SERVICE_BACKUP_ENCRYPTION_ROOT="${SERVICE_ROOT}/backup-encryption/"
 
-  rm -rf "$SERVICE_BACKUP_ENCRYPTION_ROOT"
+  rm "$SERVICE_BACKUP_ENCRYPTION_ROOT/ENCRYPT_WITH_PUBLIC_KEY_ID"
 }
 
 service_container_rm() {

--- a/subcommands/backup-unset-public-key-encryption
+++ b/subcommands/backup-unset-public-key-encryption
@@ -13,11 +13,11 @@ service-backup-unset-public-key-encryption-cmd() {
   local cmd="$PLUGIN_COMMAND_PREFIX:backup-unset-public-key-encryption" argv=("$@")
   [[ ${argv[0]} == "$cmd" ]] && shift 1
   declare SERVICE="$1"
-  is_implemented_command "$cmd" || dokku_log_fail "Not yet implemented"  # TODO: [22.03.2024 by Mykola]
+  is_implemented_command "$cmd" || dokku_log_fail "Not yet implemented"
 
   [[ -z "$SERVICE" ]] && dokku_log_fail "Please specify a valid name for the service"
   verify_service_name "$SERVICE"
-  service_backup_unset_public_key_encryption "$SERVICE"  # TODO: [22.03.2024 by Mykola]
+  service_backup_unset_public_key_encryption "$SERVICE"
 }
 
-service-backup-unset-encryption-cmd "$@"
+service-backup-unset-public-key-encryption-cmd "$@"


### PR DESCRIPTION
The "backup-unset-public-key-encryption" is not currently functioning. These changes resolve that.

I updated the set / unset functions to enable removing either the public-key-encryption or the encryption-passphrase in isolation without removing the other and added some notes to the readme.