### PR TITLE
Create symlink to source when setting up tests

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -19,15 +19,12 @@ echo "Dokku version $DOKKU_VERSION"
 
 export DOKKU_LIB_ROOT="/var/lib/dokku"
 export DOKKU_PLUGINS_ROOT="$DOKKU_LIB_ROOT/plugins/available"
-pushd "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")" >/dev/null
+PROJECT_ROOT="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"
+pushd "$PROJECT_ROOT" >/dev/null
 source "config"
 popd >/dev/null
-sudo rm -rf "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX"
-sudo mkdir -p "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX" "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/subcommands" "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/scripts" "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/templates"
-sudo find ./ -maxdepth 1 -type f -exec cp '{}' "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX" \;
-[[ -d "./scripts" ]] && sudo find ./scripts -maxdepth 1 -type f -exec cp '{}' "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/scripts" \;
-[[ -d "./subcommands" ]] && sudo find ./subcommands -maxdepth 1 -type f -exec cp '{}' "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/subcommands" \;
-[[ -d "./templates" ]] && sudo find ./templates -maxdepth 1 -type f -exec cp '{}' "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX/templates" \;
+sudo rm -f "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX"
+sudo ln -s "$PROJECT_ROOT" "$DOKKU_PLUGINS_ROOT/$PLUGIN_COMMAND_PREFIX"
 sudo mkdir -p "$PLUGIN_CONFIG_ROOT" "$PLUGIN_DATA_ROOT"
 sudo dokku plugin:enable "$PLUGIN_COMMAND_PREFIX"
 sudo dokku plugin:install


### PR DESCRIPTION
Hello!

Just sharing in case this is helpful. I found it hard to run tests while actively working on a feature because source files were copied, which meant I had to manually keep files in sync. This seemed to work for me (in the vagrant development) but may not be the correct way to do this. Please feel free to edit, or perhaps to tell me why this isn't necessary!