### PR TITLE
README: document that the link alias exposes the URL as <alias>_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ dokku postgres:link <service> <app> [--link-flags...]
 
 flags:
 
-- `-a|--alias "BLUE_DATABASE"`: an alternative alias to use for linking to an app via environment variable
+- `-a|--alias "BLUE_DATABASE"`: an alternative alias to use for linking to an app via environment variable. This exposes the database URL as `BLUE_DATABASE_URL` instead of `DATABASE_URL`
 - `-q|--querystring "pool=5"`: ampersand delimited querystring arguments to append to the service link
 - `-n|--no-restart "false"`: whether or not to restart the app on link (default: true)
 


### PR DESCRIPTION
Hello,
This has bit me several times. For example, Metabase expects the variable to be named `MB_DB_CONNECTION_URI`, so I used `-a MB_DB_CONNECTION_URI` but it exposed the URL as `MB_DB_CONNECTION_URI_URL`, which Metabase didn’t recognize. I’m not sure why there is this behavior, but if it’s better documented it can help more people.