### PR TITLE
fix: remove folder checks from help command output

### DIFF
--- a/commands
+++ b/commands
@@ -8,12 +8,4 @@ set -eo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/help-functions"
 
-if [[ ! -d $PLUGIN_CONFIG_ROOT ]]; then
-  dokku_log_fail "$PLUGIN_SERVICE: Please run: sudo dokku plugin:install"
-fi
-
-if [[ ! -d $PLUGIN_DATA_ROOT ]]; then
-  dokku_log_fail "$PLUGIN_SERVICE: Please run: sudo dokku plugin:install"
-fi
-
 fn-help "$@"


### PR DESCRIPTION
These prohibit plugins from being installed via Dockerfile and also don't do anything for the actual help output.